### PR TITLE
Fix out of memory bug with large diffs

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -68,7 +68,7 @@ export class Commit {
 
 async function hasHead(): Promise<Boolean> {
     try {
-        await execFile('git', ['show', 'HEAD']);
+        await execFile('git', ['rev-parse', '--verify', 'HEAD']);
         return true;
     } catch (err) {
         return false;


### PR DESCRIPTION
Large diffs exceeded the standard stdout buffer max size, this command just gives the commit SHA, or, if no HEAD is found, returns with an error code.