### PR TITLE
Read commits from stream

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -124,10 +124,14 @@ export async function getNewCommits(since?: Commit): Promise<CommitSequence> {
                 }
             }
         });
+        let errorBuffer = '';
+        gitProcess.stderr.on('data', data => {
+            errorBuffer += data.toString();
+        });
         gitProcess.on('error', reject);
         gitProcess.on('exit', code => {
             if (code !== 0) {
-                reject(new Error('git errored: ' + code));
+                reject(new Error(`git errored: ${code}\n${errorBuffer}`));
             }
             const parsedLog = parseGitLog(buffer);
             for (const commit of parsedLog) {

--- a/src/git.ts
+++ b/src/git.ts
@@ -108,7 +108,7 @@ export async function getNewCommits(since?: Commit): Promise<CommitSequence> {
     if (since) {
         args.push(headBehindLastMigration ? 'HEAD..' + since.sha1 : since.sha1 + '..HEAD');
     }
-    const commits = await (new Promise(async (resolve, reject) => {
+    const commits = await (new Promise<CommitSequence>(async (resolve, reject) => {
         const gitProcess = await spawn('git', args);
         let buffer = '';
         let parsedCommits = new CommitSequence();
@@ -126,7 +126,7 @@ export async function getNewCommits(since?: Commit): Promise<CommitSequence> {
             }
             resolve(new CommitSequence(...parsedCommits, ...parseGitLog(buffer)));
         });
-    })) as CommitSequence;
+    }));
     commits.isReversed = headBehindLastMigration;
     return commits;
 }

--- a/src/git.ts
+++ b/src/git.ts
@@ -126,10 +126,12 @@ export async function getNewCommits(since?: Commit): Promise<CommitSequence> {
         });
         let errorBuffer = '';
         gitProcess.stderr.on('data', data => {
+            /* istanbul ignore next */
             errorBuffer += data.toString();
         });
         gitProcess.on('error', reject);
         gitProcess.on('exit', code => {
+            /* istanbul ignore next */
             if (code !== 0) {
                 reject(new Error(`git errored: ${code}\n${errorBuffer}`));
             }

--- a/src/git.ts
+++ b/src/git.ts
@@ -109,12 +109,7 @@ export async function getNewCommits(since?: Commit): Promise<CommitSequence> {
         args.push(headBehindLastMigration ? 'HEAD..' + since.sha1 : since.sha1 + '..HEAD');
     }
     const commits = await (new Promise<CommitSequence>((resolve, reject) => {
-        let gitProcess: ChildProcess;
-        try {
-            gitProcess = spawn('git', args);
-        } catch (error) {
-            reject(error);
-        }
+        const gitProcess = spawn('git', args);
         let buffer = '';
         const parsedCommits = new CommitSequence();
         gitProcess.stdout.on('data', data => {

--- a/src/git.ts
+++ b/src/git.ts
@@ -108,8 +108,8 @@ export async function getNewCommits(since?: Commit): Promise<CommitSequence> {
     if (since) {
         args.push(headBehindLastMigration ? 'HEAD..' + since.sha1 : since.sha1 + '..HEAD');
     }
-    const commits = await (new Promise<CommitSequence>(async (resolve, reject) => {
-        const gitProcess = await spawn('git', args);
+    const commits = await (new Promise<CommitSequence>((resolve, reject) => {
+        const gitProcess = spawn('git', args);
         let buffer = '';
         let parsedCommits = new CommitSequence();
         gitProcess.stdout.on('data', data => {


### PR DESCRIPTION
Having many commits in a repo (~1500) caused merkel to fail because maxBufferSize of execFile has been exceeded.