### PR TITLE
fix(cli): always set head using the up/down cli commands

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,7 @@ export class Status {
                 const hasChanged = await adapter.waitForPending(logger)
 
                 if (hasChanged) {
-                    logger.log('The migrations have changed, reloading..\n\n')
+                    logger.log('The pending migrations have changed, reloading..\n\n')
                     continue
                 }
                 // create pending tasks


### PR DESCRIPTION
Fixes an error where using the `up` command caused an error because `head` has not set