### PR TITLE
feat: add config lookback flag to merkel configuration

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -194,13 +194,18 @@ export interface GenerateOptions {
 /** Options for [[createConfig]] */
 export interface MerkelConfiguration {
     /** The directory where new migration files should be generated */
-    migrationDir: string
+    migrationDir?: string
 
     /**
      * The directory where the JavaScript migration files can be found.
      * Can differ from `migrationDir` when using a transpiler.
      */
-    migrationOutDir: string
+    migrationOutDir?: string
+
+    /**
+     * Whether to use the config for each migration based on the commit where it was added.
+     */
+    configLookback?: boolean
 }
 
 /**

--- a/src/migration.ts
+++ b/src/migration.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk'
 import * as fs from 'mz/fs'
 import { resolve, sep } from 'path'
 import { DbAdapter } from './adapter'
-import { Commit, getConfigurationForCommit } from './git'
+import { Commit, getConfigurationForCommit, getHead } from './git'
 
 export type TaskType = 'up' | 'down'
 
@@ -147,9 +147,12 @@ export class Task {
         await adapter.checkIfTaskCanExecute(this)
         let migrationExports: any
         if (commit) {
-            const config = await getConfigurationForCommit(commit)
-            if (config && config.migrationOutDir) {
-                migrationDir = config.migrationOutDir
+            const currentConfig = await getConfigurationForCommit(await getHead())
+            if (!(currentConfig && currentConfig.configLookback === false)) {
+                const config = await getConfigurationForCommit(commit)
+                if (config && config.migrationOutDir) {
+                    migrationDir = config.migrationOutDir
+                }
             }
         }
         const path = await this.migration.getPath(migrationDir)

--- a/src/migration.ts
+++ b/src/migration.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk'
 import * as fs from 'mz/fs'
 import { resolve, sep } from 'path'
 import { DbAdapter } from './adapter'
-import { Commit, getConfigurationForCommit, getHead } from './git'
+import { Commit, getConfigurationForCommit } from './git'
 
 export type TaskType = 'up' | 'down'
 
@@ -147,7 +147,7 @@ export class Task {
         await adapter.checkIfTaskCanExecute(this)
         let migrationExports: any
         if (commit) {
-            const currentConfig = await getConfigurationForCommit(await getHead())
+            const currentConfig = await getConfigurationForCommit(new Commit({ sha1: 'HEAD' }))
             if (!(currentConfig && currentConfig.configLookback === false)) {
                 const config = await getConfigurationForCommit(commit)
                 if (config && config.migrationOutDir) {


### PR DESCRIPTION
So it's possible to move migration files over to a new place without rebasing the whole repository